### PR TITLE
Create OCRService.java

### DIFF
--- a/logicaldoc-ce-ocr/src/main/java/com/logicaldoc/ocr/OCRService.java
+++ b/logicaldoc-ce-ocr/src/main/java/com/logicaldoc/ocr/OCRService.java
@@ -1,0 +1,14 @@
+package com.logicaldoc.gui.frontend.client.services;
+
+import java.util.List;
+import com.logicaldoc.gui.common.client.ServerException;
+import com.logicaldoc.gui.common.client.beans.GUIParameter;
+
+public interface OCRService {
+/**
+* upload the configuration of OCR
+* @return GUIParameter list
+* @throws ServerException
+* */
+  GUIParameter[] loadSettings() throws ServerException;
+}


### PR DESCRIPTION
When I built this project using maven, I encountered with the problem that "[ERROR] COMPILATION ERROR : [INFO] -------------------------------------------------------------
[ERROR] /home/kitty/community-extensions-8.9.1/logicaldoc-ce-ocr/src/main/java/com/logicaldoc/ocr/OCRServiceImpl.java:[22,8] com.logicaldoc.ocr.OCRSe    rviceImpl is not abstract and does not override abstract method loadSettings() in com.logicaldoc.gui.frontend.client.services.OCRService
[ERROR] /home/kitty/community-extensions-8.9.1/logicaldoc-ce-ocr/src/main/java/com/logicaldoc/ocr/OCRServiceImpl.java:[27,31] loadSettings() in com.l    ogicaldoc.ocr.OCRServiceImpl cannot implement loadSettings() in com.logicaldoc.gui.frontend.client.services.OCRService
  return type com.logicaldoc.gui.common.client.beans.GUIParameter[] is not compatible with java.util.List<com.logicaldoc.gui.common.client.beans.GUIP    arameter>
[ERROR] /home/kitty/community-extensions-8.9.1/logicaldoc-ce-ocr/src/main/java/com/logicaldoc/ocr/OCRServiceImpl.java:[26,9] method does not override     or implement a method from a supertype
"